### PR TITLE
Fix materials errors and rebuilding tesseract_rviz dependencies

### DIFF
--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -24,8 +24,7 @@ find_package(ros_industrial_cmake_boilerplate REQUIRED)
 find_package(console_bridge REQUIRED)
 
 # Ogre
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(OGRE OGRE)
+find_package(OGRE REQUIRED)
 link_directories(${OGRE_LIBRARY_DIRS} )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets)

--- a/tesseract_rviz/src/environment_plugin/conversions.cpp
+++ b/tesseract_rviz/src/environment_plugin/conversions.cpp
@@ -343,7 +343,7 @@ Ogre::SceneNode* loadLinkWireBox(Ogre::SceneManager& scene,
   wire_box->setCastShadows(false);
   wire_box->estimateVertexCount(12);
   std::string mat_name = "RVIZ/Green";
-  wire_box->begin(mat_name, Ogre::RenderOperation::OT_LINE_LIST);
+  wire_box->begin(mat_name, Ogre::RenderOperation::OT_LINE_LIST, "rviz_rendering");
 
   Ogre::Vector3 max = aabb.getMaximum();
   Ogre::Vector3 min = aabb.getMinimum();
@@ -744,7 +744,7 @@ Ogre::MaterialPtr loadLinkMaterial(Ogre::SceneManager& scene,
 {
   if (link.visual.empty() || !link.visual[0]->material)
   {
-    return Ogre::MaterialManager::getSingleton().getByName("RVIZ/ShadedRed");
+    return Ogre::MaterialManager::getSingleton().getByName("RVIZ/ShadedRed", "rviz_rendering");
   }
 
   Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(


### PR DESCRIPTION
rviz materials exist in the "rviz_rendering" ogre material group.
find_package is recommended over PkgConfig.