### PR TITLE
Concurrent `events_` vector modification and iteration fix

### DIFF
--- a/tesseract_rviz/src/ros_scene_graph_render_manager.cpp
+++ b/tesseract_rviz/src/ros_scene_graph_render_manager.cpp
@@ -123,226 +123,230 @@ void ROSSceneGraphRenderManager::render()
     return entity_manager;
   };
 
-  for (const auto& event : events_)
+  while (!events_.empty())
   {
-    if (!event)
+    auto events(std::move(events_));
+    for (const auto& event : events)
     {
-      continue;
-    }
-    if (event->type() == tesseract_gui::events::SceneGraphClear::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphClear&>(*event);
-      data_->clear(e.getComponentInfo());
-    }
-    else if (event->type() == tesseract_gui::events::SceneGraphSet::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphSet&>(*event);
-      data_->clear(e.getComponentInfo());
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      loadSceneGraph(*data_->scene_manager, *data_->scene_node, *entity_manager, *e.getSceneGraph(), "");
-    }
-    else if (event->type() == tesseract_gui::events::SceneGraphAddLink::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphAddLink&>(*event);
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      auto entity_container = entity_manager->getEntityContainer(e.getLink()->getName());
-      Ogre::SceneNode* sn = loadLink(*data_->scene_manager, *entity_container, *e.getLink());
-      data_->scene_node->addChild(sn);
-    }
-    else if (event->type() == tesseract_gui::events::SceneGraphRemoveLink::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphRemoveLink&>(*event);
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      if (entity_manager->hasEntityContainer(e.getLinkName()))
+      if (!event)
       {
-        auto entity_container = entity_manager->getEntityContainer(e.getLinkName());
-        data_->clear(*entity_container);
-        entity_container->clear();
-        entity_manager->removeEntityContainer(e.getLinkName());
+        continue;
       }
-    }
-    else if (event->type() == tesseract_gui::events::SceneGraphModifyLinkVisibility::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphModifyLinkVisibility&>(*event);
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      for (const auto& link_name : e.getLinkNames())
+      if (event->type() == tesseract_gui::events::SceneGraphClear::kType)
       {
-        if (entity_manager->hasEntityContainer(link_name))
+        auto& e = static_cast<tesseract_gui::events::SceneGraphClear&>(*event);
+        data_->clear(e.getComponentInfo());
+      }
+      else if (event->type() == tesseract_gui::events::SceneGraphSet::kType)
+      {
+        auto& e = static_cast<tesseract_gui::events::SceneGraphSet&>(*event);
+        data_->clear(e.getComponentInfo());
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        loadSceneGraph(*data_->scene_manager, *data_->scene_node, *entity_manager, *e.getSceneGraph(), "");
+      }
+      else if (event->type() == tesseract_gui::events::SceneGraphAddLink::kType)
+      {
+        auto& e = static_cast<tesseract_gui::events::SceneGraphAddLink&>(*event);
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        auto entity_container = entity_manager->getEntityContainer(e.getLink()->getName());
+        Ogre::SceneNode* sn = loadLink(*data_->scene_manager, *entity_container, *e.getLink());
+        data_->scene_node->addChild(sn);
+      }
+      else if (event->type() == tesseract_gui::events::SceneGraphRemoveLink::kType)
+      {
+        auto& e = static_cast<tesseract_gui::events::SceneGraphRemoveLink&>(*event);
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        if (entity_manager->hasEntityContainer(e.getLinkName()))
         {
-          tesseract_gui::EntityContainer::Ptr entity_container = entity_manager->getEntityContainer(link_name);
-
-          bool link_visible{ true };
-          // Link Property
-          if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, link_name))
-          {
-            auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, link_name);
-            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-
-            if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::LINK ||
-                e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
-            {
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-            }
-
-            link_visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-            sn->setVisible(link_visible, true);
-          }
-
-          // Link Visual Property
-          std::string visual_key = link_name + "::Visuals";
-          if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
-          {
-            auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
-            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-
-            if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::VISUAL ||
-                e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
-            {
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-            }
-
-            bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-            sn->setVisible(link_visible & visible, true);
-          }
-
-          // Link Collision Property
-          visual_key = link_name + "::Collisions";
-          if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
-          {
-            auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
-            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-
-            if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::COLLISION ||
-                e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
-            {
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-            }
-
-            bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-            sn->setVisible(link_visible & visible, true);
-          }
-
-          // Link WireBox Property
-          visual_key = link_name + "::WireBox";
-          if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
-          {
-            auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
-            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-
-            if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::WIREBOX ||
-                e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
-            {
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-            }
-
-            bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-            sn->setVisible(link_visible & visible, true);
-          }
-
-          // Link Axis Property
-          visual_key = link_name + "::Axis";
-          if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
-          {
-            auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
-            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-
-            if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::AXIS ||
-                e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
-            {
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-            }
-
-            bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-            sn->setVisible(link_visible & visible, true);
-          }
+          auto entity_container = entity_manager->getEntityContainer(e.getLinkName());
+          data_->clear(*entity_container);
+          entity_container->clear();
+          entity_manager->removeEntityContainer(e.getLinkName());
         }
       }
-    }
-    else if (event->type() == tesseract_gui::events::SceneGraphModifyLinkVisibilityALL::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneGraphModifyLinkVisibilityALL&>(*event);
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      for (const auto& entity_container : entity_manager->getEntityContainers())
+      else if (event->type() == tesseract_gui::events::SceneGraphModifyLinkVisibility::kType)
       {
-        for (const auto& ns : entity_container.second->getTrackedEntities(tesseract_gui::EntityContainer::VISUAL_NS))
+        auto& e = static_cast<tesseract_gui::events::SceneGraphModifyLinkVisibility&>(*event);
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        for (const auto& link_name : e.getLinkNames())
         {
-          std::vector<std::string> sub_ns = tesseract_gui::getNamespaces(ns.first);
-          if (sub_ns.size() == 2)
+          if (entity_manager->hasEntityContainer(link_name))
           {
-            if (sub_ns[1] == "Visuals" || sub_ns[1] == "Collisions")
+            tesseract_gui::EntityContainer::Ptr entity_container = entity_manager->getEntityContainer(link_name);
+
+            bool link_visible{ true };
+            // Link Property
+            if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, link_name))
             {
-              auto link_entity =
-                  entity_container.second->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, sub_ns[0]);
-              Ogre::SceneNode* link_visual_node = data_->scene_manager->getSceneNode(link_entity.unique_name);
+              auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, link_name);
+              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
 
-              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::LINK)
+              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::LINK ||
+                  e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
               {
-                link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-                bool link_visible =
-                    Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-
-                Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
-                bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-                sn->setVisible(link_visible & visible, true);
-              }
-
-              if (sub_ns[1] == "Visuals" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::VISUAL)
-              {
-                if (e.visible())
-                  link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-
-                bool link_visible =
-                    Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-                Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
                 sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-                sn->setVisible(link_visible & e.visible(), true);
               }
 
-              if (sub_ns[1] == "Collisions" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::COLLISION)
+              link_visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+              sn->setVisible(link_visible, true);
+            }
+
+            // Link Visual Property
+            std::string visual_key = link_name + "::Visuals";
+            if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
+            {
+              auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
+              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
+
+              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::VISUAL ||
+                  e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
               {
-                if (e.visible())
-                  link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-
-                bool link_visible =
-                    Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
-                Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
                 sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-                sn->setVisible(link_visible & e.visible(), true);
               }
+
+              bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+              sn->setVisible(link_visible & visible, true);
             }
-            else if (sub_ns[1] == "Axis" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::AXIS)
+
+            // Link Collision Property
+            visual_key = link_name + "::Collisions";
+            if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
             {
-              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-              sn->setVisible(e.visible(), true);
+              auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
+              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
+
+              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::COLLISION ||
+                  e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
+              {
+                sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+              }
+
+              bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+              sn->setVisible(link_visible & visible, true);
             }
-            else if (sub_ns[1] == "WireBox" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::WIREBOX)
+
+            // Link WireBox Property
+            visual_key = link_name + "::WireBox";
+            if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
             {
-              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
-              sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
-              sn->setVisible(e.visible(), true);
+              auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
+              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
+
+              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::WIREBOX ||
+                  e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
+              {
+                sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+              }
+
+              bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+              sn->setVisible(link_visible & visible, true);
+            }
+
+            // Link Axis Property
+            visual_key = link_name + "::Axis";
+            if (entity_container->hasTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key))
+            {
+              auto entity = entity_container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, visual_key);
+              Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
+
+              if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::AXIS ||
+                  e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::ALL)
+              {
+                sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+              }
+
+              bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+              sn->setVisible(link_visible & visible, true);
             }
           }
         }
       }
-    }
-    else if (event->type() == tesseract_gui::events::SceneStateChanged::kType)
-    {
-      auto& e = static_cast<tesseract_gui::events::SceneStateChanged&>(*event);
-      tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
-      for (const auto& pair : e.getState().link_transforms)
+      else if (event->type() == tesseract_gui::events::SceneGraphModifyLinkVisibilityALL::kType)
       {
-        if (entity_manager->hasEntityContainer(pair.first))
+        auto& e = static_cast<tesseract_gui::events::SceneGraphModifyLinkVisibilityALL&>(*event);
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        for (const auto& entity_container : entity_manager->getEntityContainers())
         {
-          auto container = entity_manager->getEntityContainer(pair.first);
-          Ogre::Vector3 position;
-          Ogre::Quaternion orientation;
-          toOgre(position, orientation, pair.second);
+          for (const auto& ns : entity_container.second->getTrackedEntities(tesseract_gui::EntityContainer::VISUAL_NS))
+          {
+            std::vector<std::string> sub_ns = tesseract_gui::getNamespaces(ns.first);
+            if (sub_ns.size() == 2)
+            {
+              if (sub_ns[1] == "Visuals" || sub_ns[1] == "Collisions")
+              {
+                auto link_entity =
+                    entity_container.second->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, sub_ns[0]);
+                Ogre::SceneNode* link_visual_node = data_->scene_manager->getSceneNode(link_entity.unique_name);
 
-          auto entity = container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, pair.first);
-          Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
-          sn->setPosition(position);
-          sn->setOrientation(orientation);
+                if (e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::LINK)
+                {
+                  link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+                  bool link_visible =
+                      Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+
+                  Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
+                  bool visible = Ogre::any_cast<bool>(sn->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+                  sn->setVisible(link_visible & visible, true);
+                }
+
+                if (sub_ns[1] == "Visuals" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::VISUAL)
+                {
+                  if (e.visible())
+                    link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+
+                  bool link_visible =
+                      Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+                  Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
+                  sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+                  sn->setVisible(link_visible & e.visible(), true);
+                }
+
+                if (sub_ns[1] == "Collisions" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::COLLISION)
+                {
+                  if (e.visible())
+                    link_visual_node->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+
+                  bool link_visible =
+                      Ogre::any_cast<bool>(link_visual_node->getUserObjectBindings().getUserAny(USER_VISIBILITY));
+                  Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
+                  sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+                  sn->setVisible(link_visible & e.visible(), true);
+                }
+              }
+              else if (sub_ns[1] == "Axis" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::AXIS)
+              {
+                Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
+                sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+                sn->setVisible(e.visible(), true);
+              }
+              else if (sub_ns[1] == "WireBox" && e.getVisibilityFlags() & tesseract_gui::LinkVisibilityFlags::WIREBOX)
+              {
+                Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(ns.second.unique_name);
+                sn->getUserObjectBindings().setUserAny(USER_VISIBILITY, Ogre::Any(e.visible()));
+                sn->setVisible(e.visible(), true);
+              }
+            }
+          }
+        }
+      }
+      else if (event->type() == tesseract_gui::events::SceneStateChanged::kType)
+      {
+        auto& e = static_cast<tesseract_gui::events::SceneStateChanged&>(*event);
+        tesseract_gui::EntityManager::Ptr entity_manager = getEntityManager(e.getComponentInfo());
+        for (const auto& pair : e.getState().link_transforms)
+        {
+          if (entity_manager->hasEntityContainer(pair.first))
+          {
+            auto container = entity_manager->getEntityContainer(pair.first);
+            Ogre::Vector3 position;
+            Ogre::Quaternion orientation;
+            toOgre(position, orientation, pair.second);
+
+            auto entity = container->getTrackedEntity(tesseract_gui::EntityContainer::VISUAL_NS, pair.first);
+            Ogre::SceneNode* sn = data_->scene_manager->getSceneNode(entity.unique_name);
+            sn->setPosition(position);
+            sn->setOrientation(orientation);
+          }
         }
       }
     }


### PR DESCRIPTION
There were some `events_` being added inside `loadSceneGraph()` while the same `events_` vector was being iterated. This situation [makes](https://stackoverflow.com/questions/5638323/modifying-a-data-structure-while-iterating-over-it) the iterators invalid, causing program to crash